### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -284,6 +284,9 @@ func (r *Reader) matchFilters(log *AuditLog, params QueryParams) bool {
 
 // VerifyLogFile 验证日志文件的完整性
 func (r *Reader) VerifyLogFile(filename string) (bool, error) {
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
+		return false, fmt.Errorf("invalid file name")
+	}
 	file, err := os.Open(filepath.Join(r.baseDir, filename))
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Potential fix for [https://github.com/shuakami/Lauth/security/code-scanning/9](https://github.com/shuakami/Lauth/security/code-scanning/9)

To fix the problem, we need to validate the `filename` parameter to ensure it does not contain any path traversal sequences or invalid characters. This can be done by checking for the presence of path separators (`/` or `\`) and sequences like `..`. If the `filename` is expected to be a single file name, we can reject any input that contains these characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
