### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -65,6 +65,11 @@ func (r *Reader) ReadLogs(params QueryParams) ([]*AuditLog, error) {
 
 // readAppLogs 读取指定应用的日志
 func (r *Reader) readAppLogs(appID string, params QueryParams) ([]*AuditLog, error) {
+	// 验证 appID
+	if strings.Contains(appID, "/") || strings.Contains(appID, "\\") || strings.Contains(appID, "..") {
+		return nil, fmt.Errorf("invalid appID: %s", appID)
+	}
+
 	// 加载应用索引
 	index, err := r.loadIndex(appID)
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/shuakami/Lauth/security/code-scanning/8](https://github.com/shuakami/Lauth/security/code-scanning/8)

To fix the problem, we need to validate the `appID` parameter to ensure it does not contain any path separators or parent directory references. This will prevent directory traversal attacks and ensure that the constructed paths are safe.

1. Add a validation step for the `appID` parameter in the `readAppLogs` function.
2. Ensure that the `appID` does not contain any path separators ("/" or "\\") or ".." sequences.
3. If the validation fails, return an error indicating an invalid `appID`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
